### PR TITLE
Add analytics module

### DIFF
--- a/Game_Territory/analytics.py
+++ b/Game_Territory/analytics.py
@@ -1,0 +1,26 @@
+from django.db.models import Sum, Count, F
+
+from .models import Order, OrderItem
+
+
+def order_status_counts():
+    """Return order counts grouped by status."""
+    return Order.objects.values('status').annotate(count=Count('status'))
+
+
+def total_revenue():
+    """Return total revenue from paid orders."""
+    result = OrderItem.objects.filter(order__is_paid=True).aggregate(
+        total=Sum(F('price') * F('quantity'))
+    )
+    return result['total'] or 0
+
+
+def top_products(limit=5):
+    """Return most sold products by quantity."""
+    return (
+        OrderItem.objects.filter(order__is_paid=True)
+        .values('product__name')
+        .annotate(quantity=Sum('quantity'))
+        .order_by('-quantity')[:limit]
+    )

--- a/Game_Territory/tests.py
+++ b/Game_Territory/tests.py
@@ -1,3 +1,52 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
 
-# Create your tests here.
+from .signals import create_user_profile, save_user_profile
+
+from .models import Product, Order, OrderItem
+from . import analytics
+
+settings.MIGRATION_MODULES = {"Game_Territory": None}
+
+@override_settings(MIGRATION_MODULES={"Game_Territory": None})
+class AnalyticsTests(TestCase):
+    def setUp(self):
+        post_save.disconnect(create_user_profile, sender=User)
+        post_save.disconnect(save_user_profile, sender=User)
+        self.user = User.objects.create_user(username="tester")
+        self.product = Product.objects.create(
+            name="Test",
+            description="test",
+            price=10,
+            stock=5,
+        )
+        self.order = Order.objects.create(
+            customer=self.user,
+            status="processed",
+            delivery_method="pickup",
+            full_name="Tester",
+            phone="123",
+            is_paid=True,
+        )
+        OrderItem.objects.create(
+            order=self.order,
+            product=self.product,
+            quantity=2,
+            price=10,
+        )
+
+    def test_total_revenue(self):
+        self.assertEqual(analytics.total_revenue(), 20)
+
+    def test_order_status_counts(self):
+        counts = {c["status"]: c["count"] for c in analytics.order_status_counts()}
+        self.assertEqual(counts.get("processed"), 1)
+
+    def test_top_products(self):
+        top = analytics.top_products(1)[0]
+        self.assertEqual(top["product__name"], "Test")
+        self.assertEqual(top["quantity"], 2)
+
+

--- a/Game_Territory/urls.py
+++ b/Game_Territory/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('users/<int:user_id>/update_role/<str:role>/', views.update_user_role, name='update_user_role'),
     path('order/<int:order_id>/pay/', views.process_payment, name='process_payment'),
     path('statistics/orders/', views.order_statistics, name='order_statistics'),
+    path('analytics/', views.analytics_dashboard, name='analytics_dashboard'),
     path('cart/', views.cart_detail, name='cart_detail'),
     path('cart/add/<int:product_id>/', views.add_to_cart, name='add_to_cart'),
     path('cart/remove/<int:item_id>/', views.remove_from_cart, name='remove_from_cart'),

--- a/Game_Territory/views.py
+++ b/Game_Territory/views.py
@@ -14,10 +14,12 @@ from django.core.mail import send_mail
 from django.contrib import messages
 from django.shortcuts import render, redirect
 from django.db.models import Sum
+from . import analytics
 import random
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth import update_session_auth_hash
 from django.http import JsonResponse
+import json
 
 @login_required
 def personal_info(request):
@@ -181,6 +183,36 @@ def order_statistics(request):
     buffer.seek(0)
 
     return HttpResponse(buffer, content_type='image/png')
+
+
+@login_required
+def analytics_dashboard(request):
+    """Display simple analytics charts for managers and admins."""
+    is_admin = request.user.is_superuser
+    is_manager = request.user.groups.filter(name='manager').exists()
+    if not is_admin and not is_manager:
+        return redirect('Game_Territory:profile')
+
+    status_counts = analytics.order_status_counts()
+    revenue = analytics.total_revenue()
+    top = analytics.top_products()
+
+    status_labels = [item['status'] for item in status_counts]
+    status_data = [item['count'] for item in status_counts]
+    product_labels = [item['product__name'] for item in top]
+    product_data = [item['quantity'] for item in top]
+
+    return render(
+        request,
+        'Game_Territory/analytics_dashboard.html',
+        {
+            'status_labels': json.dumps(status_labels, ensure_ascii=False),
+            'status_data': json.dumps(status_data),
+            'product_labels': json.dumps(product_labels, ensure_ascii=False),
+            'product_data': json.dumps(product_data),
+            'total_revenue': revenue,
+        },
+    )
 
 # def add_to_cart(request, product_id):
 #     product = get_object_or_404(Product, id=product_id)

--- a/templates/Game_Territory/admin_panel.html
+++ b/templates/Game_Territory/admin_panel.html
@@ -9,6 +9,7 @@
         <button class="btn btn-dark mb-2" onclick="loadContent('{% url 'Game_Territory:user_management' %}')">Управление пользователями</button>
         <button class="btn btn-dark mb-2" onclick="loadContent('{% url 'Game_Territory:manage_products' %}')">Управление товарами</button>
         <button class="btn btn-dark mb-2" onclick="loadContent('{% url 'Game_Territory:order_management' %}')">Управление заказами</button>
+        <button class="btn btn-dark mb-2" onclick="loadContent('{% url 'Game_Territory:analytics_dashboard' %}')">Аналитика</button>
     </div>
 </div>
 

--- a/templates/Game_Territory/analytics_dashboard.html
+++ b/templates/Game_Territory/analytics_dashboard.html
@@ -1,0 +1,48 @@
+<div class="container mt-4">
+    <h2>Аналитика</h2>
+    <div class="row">
+        <div class="col-md-6">
+            <canvas id="statusChart"></canvas>
+        </div>
+        <div class="col-md-6">
+            <canvas id="productChart"></canvas>
+        </div>
+    </div>
+    <div class="mt-3">
+        <h5>Общий доход: {{ total_revenue }} руб.</h5>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    const statusCtx = document.getElementById('statusChart').getContext('2d');
+    new Chart(statusCtx, {
+        type: 'bar',
+        data: {
+            labels: {{ status_labels|safe }},
+            datasets: [{
+                label: 'Количество заказов',
+                data: {{ status_data|safe }},
+                backgroundColor: 'rgba(54, 162, 235, 0.6)'
+            }]
+        }
+    });
+
+    const productCtx = document.getElementById('productChart').getContext('2d');
+    new Chart(productCtx, {
+        type: 'pie',
+        data: {
+            labels: {{ product_labels|safe }},
+            datasets: [{
+                data: {{ product_data|safe }},
+                backgroundColor: [
+                    'rgba(255, 99, 132, 0.6)',
+                    'rgba(54, 162, 235, 0.6)',
+                    'rgba(255, 206, 86, 0.6)',
+                    'rgba(75, 192, 192, 0.6)',
+                    'rgba(153, 102, 255, 0.6)'
+                ]
+            }]
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- implement `analytics.py` with helpers for order stats
- add `analytics_dashboard` view and URL
- show new analytics button in admin panel
- create `analytics_dashboard.html` with Chart.js charts
- add tests for analytics helpers

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68447720814883228c98f0d95818e7c2